### PR TITLE
feat: add .dokploy.json local project config and init command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,7 @@ Dokploy CLI is a powerful and versatile command-line tool designed to remotely m
 
 - [Installation](#installation)
 - [Usage](#usage)
+- [Project Configuration](#project-configuration)
 - [Commands](#commands)
   - [Authentication](#authentication)
   - [Project Management](#project-management)
@@ -43,6 +44,34 @@ USAGE
   $ dokploy COMMAND
 ...
 ```
+
+## Project Configuration
+
+You can create a `.dokploy.json` file in any project directory to set default values for project, environment, and application. This lets you skip interactive prompts when running commands.
+
+```sh-session
+$ cd ~/my-app
+$ dokploy init
+```
+
+This walks you through selecting a project, environment, and (optionally) an application, then writes a `.dokploy.json` file:
+
+```json
+{
+  "projectId": "abc123",
+  "environmentId": "def456",
+  "applicationId": "ghi789"
+}
+```
+
+Now commands run from that directory (or any subdirectory) will use these defaults automatically:
+
+```sh-session
+$ dokploy app deploy -y      # deploys the configured application
+$ dokploy env pull .env.local # pulls env vars without prompts
+```
+
+Flags passed on the command line always take priority over `.dokploy.json` values.
 
 ## Commands
 

--- a/src/commands/app/create.ts
+++ b/src/commands/app/create.ts
@@ -6,6 +6,7 @@ import inquirer from "inquirer";
 import { type Project, getProjects } from "../../utils/shared.js";
 import { slugify } from "../../utils/slug.js";
 import { readAuthConfig } from "../../utils/utils.js";
+import { readLocalConfig } from "../../utils/local-config.js";
 
 export interface Answers {
 	project: Project;
@@ -52,6 +53,10 @@ export default class AppCreate extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(AppCreate);
 		let { projectId, environmentId, name, description, appName } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !name || !appName) {

--- a/src/commands/app/delete.ts
+++ b/src/commands/app/delete.ts
@@ -5,6 +5,7 @@ import inquirer from "inquirer";
 
 import { getProject, getProjects, type Application } from "../../utils/shared.js";
 import { readAuthConfig } from "../../utils/utils.js";
+import { readLocalConfig } from "../../utils/local-config.js";
 import type { Answers } from "./create.js";
 
 export default class AppDelete extends Command {
@@ -42,6 +43,11 @@ export default class AppDelete extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(AppDelete);
 		let { projectId, environmentId, applicationId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
+		if (!applicationId && localConfig.applicationId) applicationId = localConfig.applicationId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !applicationId) {

--- a/src/commands/app/deploy.ts
+++ b/src/commands/app/deploy.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { getProject, getProjects, type Application } from "../../utils/shared.js";
 import inquirer from "inquirer";
 import type { Answers } from "./create.js";
+import { readLocalConfig } from "../../utils/local-config.js";
 import axios from "axios";
 
 export default class AppDeploy extends Command {
@@ -42,6 +43,11 @@ export default class AppDeploy extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(AppDeploy);
 		let { projectId, applicationId, environmentId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
+		if (!applicationId && localConfig.applicationId) applicationId = localConfig.applicationId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !applicationId || !environmentId) {

--- a/src/commands/app/stop.ts
+++ b/src/commands/app/stop.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import { getProject, getProjects, type Application } from "../../utils/shared.js";
 import type { Answers } from "./create.js";
+import { readLocalConfig } from "../../utils/local-config.js";
 import axios from "axios";
 
 export default class AppStop extends Command {
@@ -38,6 +39,11 @@ export default class AppStop extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(AppStop);
 		let { projectId, environmentId, applicationId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
+		if (!applicationId && localConfig.applicationId) applicationId = localConfig.applicationId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !applicationId) {

--- a/src/commands/database/mariadb/create.ts
+++ b/src/commands/database/mariadb/create.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import chalk from "chalk";
 import inquirer from "inquirer";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import { getProjects, type Database } from "../../../utils/shared.js";
 import { slugify } from "../../../utils/slug.js";
 import type { Answers } from "../../app/create.js";
@@ -79,6 +80,10 @@ export default class DatabaseMariadbCreate extends Command {
 			dockerImage,
 			appName 
 		} = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !name || !databaseName || !appName) {

--- a/src/commands/database/mariadb/delete.ts
+++ b/src/commands/database/mariadb/delete.ts
@@ -5,6 +5,7 @@ import inquirer from "inquirer";
 
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 
 export default class DatabaseMariadbDelete extends Command {
 	static description = "Delete a MariaDB database from a project.";
@@ -39,6 +40,10 @@ export default class DatabaseMariadbDelete extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMariadbDelete);
 		let { projectId, environmentId, mariadbId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		if (!projectId || !environmentId || !mariadbId) {
 			console.log(chalk.blue.bold("\n  Listing all Projects \n"));

--- a/src/commands/database/mariadb/deploy.ts
+++ b/src/commands/database/mariadb/deploy.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import chalk from "chalk";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import inquirer from "inquirer";
@@ -38,6 +39,10 @@ export default class DatabaseMariadbDeploy extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMariadbDeploy);
 		let { projectId, environmentId, mariadbId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !mariadbId) {

--- a/src/commands/database/mariadb/stop.ts
+++ b/src/commands/database/mariadb/stop.ts
@@ -4,6 +4,7 @@ import inquirer from "inquirer";
 import axios from "axios";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import type { Answers } from "../../app/create.js";
 
 export default class DatabaseMariadbStop extends Command {
@@ -38,6 +39,10 @@ export default class DatabaseMariadbStop extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMariadbStop);
 		let { projectId, environmentId, mariadbId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !mariadbId) {

--- a/src/commands/database/mongo/create.ts
+++ b/src/commands/database/mongo/create.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import chalk from "chalk";
 import inquirer from "inquirer";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import { getProjects, type Database } from "../../../utils/shared.js";
 import { slugify } from "../../../utils/slug.js";
 import type { Answers } from "../../app/create.js";
@@ -74,6 +75,10 @@ export default class DatabaseMongoCreate extends Command {
 			dockerImage,
 			appName 
 		} = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !name || !databaseName || !appName || !databasePassword) {

--- a/src/commands/database/mongo/delete.ts
+++ b/src/commands/database/mongo/delete.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 
 export default class DatabaseMongoDelete extends Command {
@@ -41,6 +42,10 @@ export default class DatabaseMongoDelete extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMongoDelete);
 		let { projectId, environmentId, mongoId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !mongoId) {

--- a/src/commands/database/mongo/deploy.ts
+++ b/src/commands/database/mongo/deploy.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import chalk from "chalk";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import inquirer from "inquirer";
@@ -38,6 +39,10 @@ export default class DatabaseMongoDeploy extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMongoDeploy);
 		let { projectId, environmentId, mongoId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !mongoId) {

--- a/src/commands/database/mongo/stop.ts
+++ b/src/commands/database/mongo/stop.ts
@@ -4,6 +4,7 @@ import inquirer from "inquirer";
 import axios from "axios";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import type { Answers } from "../../app/create.js";
 
 export default class DatabaseMongoStop extends Command {
@@ -38,6 +39,10 @@ export default class DatabaseMongoStop extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMongoStop);
 		let { projectId, environmentId, mongoId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !mongoId) {

--- a/src/commands/database/mysql/create.ts
+++ b/src/commands/database/mysql/create.ts
@@ -5,6 +5,7 @@ import inquirer from "inquirer";
 
 import { slugify } from "../../../utils/slug.js";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import { getProjects, type Database } from "../../../utils/shared.js";
 import type { Answers } from "../../app/create.js";
 
@@ -81,7 +82,11 @@ export default class DatabaseMysqlCreate extends Command {
 			appName 
 		} = flags;
 
-		// Modo interactivo si no se proporcionan los flags necesarios	
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
+
+		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !name || !databaseName || !appName || !databasePassword || !databaseRootPassword) {
 			console.log(chalk.blue.bold("\n  Listing all Projects \n"));
 			const projects = await getProjects(auth, this);

--- a/src/commands/database/mysql/delete.ts
+++ b/src/commands/database/mysql/delete.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 
 export default class DatabaseMysqlDelete extends Command {
@@ -41,6 +42,10 @@ export default class DatabaseMysqlDelete extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMysqlDelete);
 		let { projectId, environmentId, mysqlId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !mysqlId) {

--- a/src/commands/database/mysql/deploy.ts
+++ b/src/commands/database/mysql/deploy.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import chalk from "chalk";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import inquirer from "inquirer";
@@ -38,6 +39,10 @@ export default class DatabaseMysqlDeploy extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMysqlDeploy);
 		let { projectId, environmentId, mysqlId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !mysqlId) {

--- a/src/commands/database/mysql/stop.ts
+++ b/src/commands/database/mysql/stop.ts
@@ -4,6 +4,7 @@ import inquirer from "inquirer";
 import axios from "axios";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import type { Answers } from "../../app/create.js";
 
 export default class DatabaseMysqlStop extends Command {
@@ -38,6 +39,10 @@ export default class DatabaseMysqlStop extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseMysqlStop);
 		let { projectId, environmentId, mysqlId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !mysqlId) {

--- a/src/commands/database/postgres/create.ts
+++ b/src/commands/database/postgres/create.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import { slugify } from "../../../utils/slug.js";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import { getProjects, type Database } from "../../../utils/shared.js";
 import type { Answers } from "../../app/create.js";
 export default class DatabasePostgresCreate extends Command {
@@ -73,6 +74,10 @@ export default class DatabasePostgresCreate extends Command {
 			dockerImage,
 			appName 
 		} = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !name || !databaseName || !appName || !databasePassword) {

--- a/src/commands/database/postgres/delete.ts
+++ b/src/commands/database/postgres/delete.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 
 export default class DatabasePostgresDelete extends Command {
@@ -41,6 +42,10 @@ export default class DatabasePostgresDelete extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabasePostgresDelete);
 		let { projectId, environmentId, postgresId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !postgresId) {

--- a/src/commands/database/postgres/deploy.ts
+++ b/src/commands/database/postgres/deploy.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import chalk from "chalk";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import inquirer from "inquirer";
@@ -38,6 +39,10 @@ export default class DatabasePostgresDeploy extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabasePostgresDeploy);
 		let { projectId, environmentId, postgresId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !postgresId) {

--- a/src/commands/database/postgres/stop.ts
+++ b/src/commands/database/postgres/stop.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import chalk from "chalk";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import inquirer from "inquirer";
@@ -38,6 +39,10 @@ export default class DatabasePostgresStop extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabasePostgresStop);
 		let { projectId, environmentId, postgresId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !postgresId) {

--- a/src/commands/database/redis/create.ts
+++ b/src/commands/database/redis/create.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import inquirer from "inquirer";
 import { slugify } from "../../../utils/slug.js";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import { getProjects, type Database } from "../../../utils/shared.js";
 import type { Answers } from "../../app/create.js";
 
@@ -63,6 +64,10 @@ export default class DatabaseRedisCreate extends Command {
 			dockerImage,
 			appName 
 		} = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !name || !appName || !databasePassword) {

--- a/src/commands/database/redis/delete.ts
+++ b/src/commands/database/redis/delete.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import chalk from "chalk";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import inquirer from "inquirer";
@@ -41,6 +42,10 @@ export default class DatabaseRedisDelete extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseRedisDelete);
 		let { projectId, environmentId, redisId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !redisId) {

--- a/src/commands/database/redis/deploy.ts
+++ b/src/commands/database/redis/deploy.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import chalk from "chalk";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import inquirer from "inquirer";
@@ -38,6 +39,10 @@ export default class DatabaseRedisDeploy extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseRedisDeploy);
 		let { projectId, environmentId, redisId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !redisId) {

--- a/src/commands/database/redis/stop.ts
+++ b/src/commands/database/redis/stop.ts
@@ -1,5 +1,6 @@
 import { Command, Flags } from "@oclif/core";
 import { readAuthConfig } from "../../../utils/utils.js";
+import { readLocalConfig } from "../../../utils/local-config.js";
 import chalk from "chalk";
 import { getProject, getProjects, type Database } from "../../../utils/shared.js";
 import inquirer from "inquirer";
@@ -38,6 +39,10 @@ export default class DatabaseRedisStop extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(DatabaseRedisStop);
 		let { projectId, environmentId, redisId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId || !redisId) {

--- a/src/commands/env/pull.ts
+++ b/src/commands/env/pull.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import {getProject, getProjects} from "../../utils/shared.js";
 import inquirer from "inquirer";
 import {Answers} from "../app/create.js";
+import { readLocalConfig } from "../../utils/local-config.js";
 import fs from 'fs';
 
 export default class EnvPull extends Command {
@@ -36,34 +37,50 @@ export default class EnvPull extends Command {
             }
         }
         const auth = await readAuthConfig(this);
-        console.log(chalk.blue.bold("\n  Listing all Projects \n"));
+        const localConfig = readLocalConfig();
 
-        const projects = await getProjects(auth, this);
-        const {project} = await inquirer.prompt<Answers>([
-            {
-                choices: projects.map((project) => ({
-                    name: project.name,
-                    value: project,
-                })),
-                message: "Select the project:",
-                name: "project",
-                type: "list",
-            },
-        ]);
-        const projectId = project.projectId;
+        let projectId = localConfig.projectId;
+        let environment: any;
+
+        if (!projectId) {
+            console.log(chalk.blue.bold("\n  Listing all Projects \n"));
+            const projects = await getProjects(auth, this);
+            const {project} = await inquirer.prompt<Answers>([
+                {
+                    choices: projects.map((project) => ({
+                        name: project.name,
+                        value: project,
+                    })),
+                    message: "Select the project:",
+                    name: "project",
+                    type: "list",
+                },
+            ]);
+            projectId = project.projectId;
+        }
+
         const projectSelected = await getProject(projectId, auth, this);
 
-        const {environment} = await inquirer.prompt<any>([
-            {
-                choices: projectSelected.environments.map((environment: any) => ({
-                    name: environment.name,
-                    value: environment,
-                })),
-                message: "Select the environment:",
-                name: "environment",
-                type: "list",
-            },
-        ]);
+        if (localConfig.environmentId) {
+            environment = projectSelected.environments.find(
+                (e: any) => e.environmentId === localConfig.environmentId
+            );
+        }
+
+        if (!environment) {
+            const envAnswer = await inquirer.prompt<any>([
+                {
+                    choices: projectSelected.environments.map((environment: any) => ({
+                        name: environment.name,
+                        value: environment,
+                    })),
+                    message: "Select the environment:",
+                    name: "environment",
+                    type: "list",
+                },
+            ]);
+            environment = envAnswer.environment;
+        }
 
         const choices = [
             ...environment.applications.map((app: any) => ({

--- a/src/commands/env/push.ts
+++ b/src/commands/env/push.ts
@@ -5,6 +5,7 @@ import inquirer from "inquirer";
 import {readAuthConfig} from "../../utils/utils.js";
 import {getProject, getProjects} from "../../utils/shared.js";
 import {Answers} from "../app/create.js";
+import { readLocalConfig } from "../../utils/local-config.js";
 import axios from "axios";
 
 export default class EnvPush extends Command {
@@ -42,34 +43,50 @@ export default class EnvPush extends Command {
 
         const fileContent = fs.readFileSync(args.file, 'utf-8');
         const auth = await readAuthConfig(this);
-        console.log(chalk.blue.bold("\n  Listing all Projects \n"));
+        const localConfig = readLocalConfig();
 
-        const projects = await getProjects(auth, this);
-        const {project} = await inquirer.prompt<Answers>([
-            {
-                choices: projects.map((project) => ({
-                    name: project.name,
-                    value: project,
-                })),
-                message: "Select the project:",
-                name: "project",
-                type: "list",
-            },
-        ]);
-        const projectId = project.projectId;
+        let projectId = localConfig.projectId;
+        let environment: any;
+
+        if (!projectId) {
+            console.log(chalk.blue.bold("\n  Listing all Projects \n"));
+            const projects = await getProjects(auth, this);
+            const {project} = await inquirer.prompt<Answers>([
+                {
+                    choices: projects.map((project) => ({
+                        name: project.name,
+                        value: project,
+                    })),
+                    message: "Select the project:",
+                    name: "project",
+                    type: "list",
+                },
+            ]);
+            projectId = project.projectId;
+        }
+
         const projectSelected = await getProject(projectId, auth, this);
 
-        const {environment} = await inquirer.prompt<any>([
-            {
-                choices: projectSelected.environments.map((environment: any) => ({
-                    name: environment.name,
-                    value: environment,
-                })),
-                message: "Select the environment:",
-                name: "environment",
-                type: "list",
-            },
-        ]);
+        if (localConfig.environmentId) {
+            environment = projectSelected.environments.find(
+                (e: any) => e.environmentId === localConfig.environmentId
+            );
+        }
+
+        if (!environment) {
+            const envAnswer = await inquirer.prompt<any>([
+                {
+                    choices: projectSelected.environments.map((environment: any) => ({
+                        name: environment.name,
+                        value: environment,
+                    })),
+                    message: "Select the environment:",
+                    name: "environment",
+                    type: "list",
+                },
+            ]);
+            environment = envAnswer.environment;
+        }
 
         const choices = [
             ...environment.applications.map((app: any) => ({

--- a/src/commands/environment/create.ts
+++ b/src/commands/environment/create.ts
@@ -5,6 +5,7 @@ import inquirer from "inquirer";
 
 import { getProjects } from "../../utils/shared.js";
 import { readAuthConfig } from "../../utils/utils.js";
+import { readLocalConfig } from "../../utils/local-config.js";
 import type { Answers } from "../app/create.js";
 
 export default class EnvironmentCreate extends Command {
@@ -39,6 +40,9 @@ export default class EnvironmentCreate extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(EnvironmentCreate);
 		let { projectId, name, description } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !name) {

--- a/src/commands/environment/delete.ts
+++ b/src/commands/environment/delete.ts
@@ -5,6 +5,7 @@ import inquirer from "inquirer";
 
 import { getProjects } from "../../utils/shared.js";
 import { readAuthConfig } from "../../utils/utils.js";
+import { readLocalConfig } from "../../utils/local-config.js";
 import type { Answers } from "../app/create.js";
 
 export default class EnvironmentDelete extends Command {
@@ -37,6 +38,10 @@ export default class EnvironmentDelete extends Command {
 		const auth = await readAuthConfig(this);
 		const { flags } = await this.parse(EnvironmentDelete);
 		let { projectId, environmentId } = flags;
+
+		const localConfig = readLocalConfig();
+		if (!projectId && localConfig.projectId) projectId = localConfig.projectId;
+		if (!environmentId && localConfig.environmentId) environmentId = localConfig.environmentId;
 
 		// Modo interactivo si no se proporcionan los flags necesarios
 		if (!projectId || !environmentId) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,88 @@
+import { Command } from "@oclif/core";
+import chalk from "chalk";
+import inquirer from "inquirer";
+
+import { getProjects, type Application } from "../utils/shared.js";
+import { readAuthConfig } from "../utils/utils.js";
+import { writeLocalConfig, LOCAL_CONFIG_FILE } from "../utils/local-config.js";
+import type { Answers } from "./app/create.js";
+
+export default class Init extends Command {
+	static description = `Create a ${LOCAL_CONFIG_FILE} file in the current directory to set default project, environment, and application for CLI commands.`;
+
+	static examples = [
+		"$ <%= config.bin %> init",
+	];
+
+	public async run(): Promise<void> {
+		const auth = await readAuthConfig(this);
+
+		console.log(chalk.blue.bold("\n  Listing all Projects \n"));
+		const projects = await getProjects(auth, this);
+
+		// 1. Select project
+		const { project } = await inquirer.prompt<Answers>([
+			{
+				choices: projects.map((project) => ({
+					name: project.name,
+					value: project,
+				})),
+				message: "Select a project:",
+				name: "project",
+				type: "list",
+			},
+		]);
+
+		const config: Record<string, string> = {};
+		config.projectId = project.projectId!;
+
+		// 2. Select environment
+		if (project.environments && project.environments.length > 0) {
+			const { environment } = await inquirer.prompt([
+				{
+					choices: project.environments.map((env) => ({
+						name: `${env.name} (${env.description})`,
+						value: env,
+					})),
+					message: "Select an environment:",
+					name: "environment",
+					type: "list",
+				},
+			]);
+
+			config.environmentId = environment.environmentId;
+
+			// 3. Optionally select application
+			if (environment.applications && environment.applications.length > 0) {
+				const { selectApp } = await inquirer.prompt([
+					{
+						type: "confirm",
+						name: "selectApp",
+						message: "Do you want to set a default application?",
+						default: true,
+					},
+				]);
+
+				if (selectApp) {
+					const { selectedApp } = await inquirer.prompt([
+						{
+							choices: environment.applications.map((app: Application) => ({
+								name: app.name,
+								value: app.applicationId,
+							})),
+							message: "Select an application:",
+							name: "selectedApp",
+							type: "list",
+						},
+					]);
+
+					config.applicationId = selectedApp;
+				}
+			}
+		}
+
+		const filePath = writeLocalConfig(config);
+		this.log(chalk.green(`\nCreated ${filePath}`));
+		this.log(chalk.gray("CLI commands will now use these defaults instead of prompting interactively."));
+	}
+}

--- a/src/utils/local-config.ts
+++ b/src/utils/local-config.ts
@@ -1,0 +1,45 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export type LocalConfig = {
+	projectId?: string;
+	environmentId?: string;
+	applicationId?: string;
+};
+
+export const LOCAL_CONFIG_FILE = ".dokploy.json";
+
+/**
+ * Walk up from the given directory looking for a .dokploy.json file.
+ * Returns the parsed config if found, or an empty object if not.
+ */
+export const readLocalConfig = (startDir: string = process.cwd()): LocalConfig => {
+	let dir = path.resolve(startDir);
+
+	while (true) {
+		const candidate = path.join(dir, LOCAL_CONFIG_FILE);
+		if (fs.existsSync(candidate)) {
+			try {
+				const content = fs.readFileSync(candidate, "utf8");
+				return JSON.parse(content) as LocalConfig;
+			} catch {
+				return {};
+			}
+		}
+
+		const parent = path.dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+
+	return {};
+};
+
+/**
+ * Write a .dokploy.json file to the given directory (defaults to cwd).
+ */
+export const writeLocalConfig = (config: LocalConfig, dir: string = process.cwd()): string => {
+	const filePath = path.join(dir, LOCAL_CONFIG_FILE);
+	fs.writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n", "utf8");
+	return filePath;
+};


### PR DESCRIPTION
## Summary

- Adds `dokploy init` command to interactively create a `.dokploy.json` config file in the current directory
- All commands now read `.dokploy.json` (walking up parent directories) to fill in missing `projectId`, `environmentId`, and `applicationId` before prompting
- CLI flags always take priority over config file values
- Updates README with a new Project Configuration section

Closes #25