### PR TITLE
fix: remove trcp path prefix

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -87,7 +87,7 @@ export async function apiPost(
 ) {
 	const client = createClient();
 	const response = await client.post(
-		`/trpc/${endpoint}`,
+		`/${endpoint}`,
 		data ? { json: data } : undefined,
 	);
 	return response.data?.result?.data?.json ?? response.data;
@@ -101,6 +101,6 @@ export async function apiGet(
 	const query = params
 		? `?input=${encodeURIComponent(JSON.stringify(params))}`
 		: "";
-	const response = await client.get(`/trpc/${endpoint}${query}`);
+	const response = await client.get(`/${endpoint}${query}`);
 	return response.data?.result?.data?.json ?? response.data;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -88,9 +88,9 @@ export async function apiPost(
 	const client = createClient();
 	const response = await client.post(
 		`/${endpoint}`,
-		data ? { json: data } : undefined,
+		data,
 	);
-	return response.data?.result?.data?.json ?? response.data;
+	return response.data;
 }
 
 export async function apiGet(
@@ -98,9 +98,10 @@ export async function apiGet(
 	params?: Record<string, unknown>,
 ) {
 	const client = createClient();
-	const query = params
-		? `?input=${encodeURIComponent(JSON.stringify(params))}`
-		: "";
-	const response = await client.get(`/${endpoint}${query}`);
-	return response.data?.result?.data?.json ?? response.data;
+	const query = Object
+		.entries(params ?? {})
+		.map(([key, value]) => `${key}=${value}`)
+		.join('&')
+	const response = await client.get(`/${endpoint}?${query}`);
+	return response.data;
 }


### PR DESCRIPTION
The CLI calls /trpc/ endpoints but the server only responds on /api/ REST endpoints wich results in "Request failed with status code 400" errors. 

I migrated the broken calls to /trcp/ to the new REST endpoint schema. I made sure not to not to break params to query mappings for get and data to body mappings for post calls.

Fixes #39