### PR TITLE
fix: read CLI version from package metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import { program } from "commander";
 import { registerAuthCommand } from "./commands/auth.js";
 import { registerGeneratedCommands } from "./generated/commands.js";
 
+const packageJson = JSON.parse(
+	readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string };
+
 const pkg = {
 	name: "dokploy",
-	version: "0.3.0",
+	version: packageJson.version,
 	description: "Dokploy CLI - Manage your Dokploy server",
 };
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -6,6 +7,9 @@ import { describe, expect, it } from "vitest";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 const CLI = path.join(ROOT, "dist", "index.js");
+const packageJson = JSON.parse(
+	fs.readFileSync(path.join(ROOT, "package.json"), "utf8"),
+) as { version: string };
 
 function run(...args: string[]): string {
 	return execFileSync("node", [CLI, ...args], {
@@ -25,7 +29,7 @@ describe("CLI", () => {
 
 	it("should show version with --version", () => {
 		const output = run("--version");
-		expect(output.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+		expect(output.trim()).toBe(packageJson.version);
 	});
 
 	it("should show subcommands for application", () => {


### PR DESCRIPTION
Fixes a tiny papercut: `dokploy --version` was stuck on `0.3.0`, while the package is `0.29.2`. ngl this can make releases look stale.

Repro before:
```bash
pnpm build
node dist/index.js --version
node -p "require('./package.json').version"
```

Before: `0.3.0` vs `0.29.2`.

Now the CLI reads `package.json` at runtime, and the test checks the exact package version so it wont drift again.

Checked:
```bash
pnpm build
pnpm test
pnpm exec biome check src/index.ts tests/cli.test.ts
```

No exact issue found for this one, just related stale-version/outdated CLI threads.