### PR TITLE
fix: migrate API client to REST endpoints

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -87,7 +87,7 @@ export async function apiPost(
 ) {
 	const client = createClient();
 	const response = await client.post(
-		`/trpc/${endpoint}`,
+		`/${endpoint}`,
 		data ? { json: data } : undefined,
 	);
 	return response.data?.result?.data?.json ?? response.data;
@@ -101,6 +101,6 @@ export async function apiGet(
 	const query = params
 		? `?input=${encodeURIComponent(JSON.stringify(params))}`
 		: "";
-	const response = await client.get(`/trpc/${endpoint}${query}`);
+	const response = await client.get(`/${endpoint}${query}`);
 	return response.data?.result?.data?.json ?? response.data;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -88,9 +88,9 @@ export async function apiPost(
 	const client = createClient();
 	const response = await client.post(
 		`/${endpoint}`,
-		data ? { json: data } : undefined,
+		data,
 	);
-	return response.data?.result?.data?.json ?? response.data;
+	return response.data;
 }
 
 export async function apiGet(
@@ -98,9 +98,10 @@ export async function apiGet(
 	params?: Record<string, unknown>,
 ) {
 	const client = createClient();
-	const query = params
-		? `?input=${encodeURIComponent(JSON.stringify(params))}`
-		: "";
-	const response = await client.get(`/${endpoint}${query}`);
-	return response.data?.result?.data?.json ?? response.data;
+	const query = Object
+		.entries(params ?? {})
+		.map(([key, value]) => `${key}=${value}`)
+		.join('&')
+	const response = await client.get(`/${endpoint}?${query}`);
+	return response.data;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,10 @@ function loadEnvFile(): void {
 		const eqIndex = trimmed.indexOf("=");
 		if (eqIndex === -1) continue;
 		const key = trimmed.slice(0, eqIndex).trim();
-		const value = trimmed.slice(eqIndex + 1).trim().replace(/^["']|["']$/g, "");
+		const value = trimmed
+			.slice(eqIndex + 1)
+			.trim()
+			.replace(/^["']|["']$/g, "");
 		if (!process.env[key]) {
 			process.env[key] = value;
 		}
@@ -86,10 +89,7 @@ export async function apiPost(
 	data?: Record<string, unknown>,
 ) {
 	const client = createClient();
-	const response = await client.post(
-		`/${endpoint}`,
-		data,
-	);
+	const response = await client.post(`/${endpoint}`, data);
 	return response.data;
 }
 
@@ -98,10 +98,6 @@ export async function apiGet(
 	params?: Record<string, unknown>,
 ) {
 	const client = createClient();
-	const query = Object
-		.entries(params ?? {})
-		.map(([key, value]) => `${key}=${value}`)
-		.join('&')
-	const response = await client.get(`/${endpoint}?${query}`);
+	const response = await client.get(`/${endpoint}`, { params });
 	return response.data;
 }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const axiosMocks = vi.hoisted(() => ({
+	create: vi.fn(),
+	get: vi.fn(),
+	post: vi.fn(),
+}));
+
+vi.mock("axios", () => ({
+	default: {
+		create: axiosMocks.create,
+	},
+}));
+
 describe("readAuthConfig", () => {
 	const originalEnv = { ...process.env };
 
@@ -52,5 +64,52 @@ describe("saveAuthConfig", () => {
 	it("should write config with correct structure", async () => {
 		const { saveAuthConfig } = await import("../src/client.js");
 		expect(typeof saveAuthConfig).toBe("function");
+	});
+});
+
+describe("REST API client", () => {
+	beforeEach(() => {
+		process.env.DOKPLOY_URL = "https://test.dokploy.com";
+		process.env.DOKPLOY_API_KEY = "test-key";
+		axiosMocks.create.mockReturnValue({
+			get: axiosMocks.get,
+			post: axiosMocks.post,
+		});
+	});
+
+	afterEach(() => {
+		delete process.env.DOKPLOY_URL;
+		delete process.env.DOKPLOY_API_KEY;
+		vi.clearAllMocks();
+	});
+
+	it("sends GET parameters to the REST endpoint", async () => {
+		const responseData = { projectId: "project-1" };
+		axiosMocks.get.mockResolvedValue({ data: responseData });
+
+		const { apiGet } = await import("../src/client.js");
+		const result = await apiGet("project.one", {
+			projectId: "project with spaces",
+		});
+
+		expect(axiosMocks.get).toHaveBeenCalledWith("/project.one", {
+			params: { projectId: "project with spaces" },
+		});
+		expect(result).toEqual(responseData);
+	});
+
+	it("sends POST data directly to the REST endpoint", async () => {
+		const requestData = { name: "My Project" };
+		const responseData = { projectId: "project-1", ...requestData };
+		axiosMocks.post.mockResolvedValue({ data: responseData });
+
+		const { apiPost } = await import("../src/client.js");
+		const result = await apiPost("project.create", requestData);
+
+		expect(axiosMocks.post).toHaveBeenCalledWith(
+			"/project.create",
+			requestData,
+		);
+		expect(result).toEqual(responseData);
 	});
 });


### PR DESCRIPTION
## Summary

- migrate CLI requests from the legacy `/trpc` transport to Dokploy's REST endpoints under `/api`
- pass GET parameters through Axios so values are encoded correctly
- send POST bodies directly and return REST response payloads without the tRPC envelope
- add regression coverage for parameterized GET and POST requests

## Root cause

The generated commands call `apiGet` and `apiPost`, but those helpers still used tRPC URLs and payload envelopes. Current Dokploy servers expose these procedures through REST endpoints, causing parameterized commands such as `project one` to fail with HTTP 400.

This incorporates and preserves the original commits from #40 by @OskarWiedeweg, then adds encoded query handling and regression tests.

Fixes #39.

## Validation

- generated 544 commands from the current OpenAPI specification
- TypeScript build completed successfully
- all 20 tests passed
- Biome check passed for the changed client and tests
- verified `project all` and parameterized `project one` against a live Dokploy instance
