### PR TITLE
fix: wrap GET input params in tRPC v11 { json } envelope

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -98,8 +98,13 @@ export async function apiGet(
 	params?: Record<string, unknown>,
 ) {
 	const client = createClient();
+	// tRPC v11 servers require the GET `input` query param to be wrapped in a
+	// { json: ... } envelope (see https://trpc.io/docs/client/http-link). A
+	// bare object is deserialized as `undefined` and every GET call fails with
+	// HTTP 400. The envelope is also accepted by older tRPC v10 servers, so it
+	// works against all Dokploy server versions.
 	const query = params
-		? `?input=${encodeURIComponent(JSON.stringify(params))}`
+		? `?input=${encodeURIComponent(JSON.stringify({ json: params }))}`
 		: "";
 	const response = await client.get(`/trpc/${endpoint}${query}`);
 	return response.data?.result?.data?.json ?? response.data;

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("axios", () => {
+	return {
+		default: {
+			create: () => ({
+				get: () => Promise.resolve({ data: {} }),
+				post: () => Promise.resolve({ data: {} }),
+			}),
+		},
+	};
+});
+
 describe("readAuthConfig", () => {
 	const originalEnv = { ...process.env };
 
@@ -45,6 +56,52 @@ describe("readAuthConfig", () => {
 		const config = readAuthConfig();
 
 		expect(config.token).toBe("api-key");
+	});
+});
+
+describe("apiGet", () => {
+	it("should pass GET params in the tRPC { json: ... } input envelope", async () => {
+		process.env.DOKPLOY_URL = "https://test.dokploy.com";
+		process.env.DOKPLOY_API_KEY = "test-key-123";
+
+		const urls: string[] = [];
+		const axiosMock = await import("axios");
+		axiosMock.default.create = () =>
+			({
+				get: async (url: string) => {
+					urls.push(url);
+					return { data: {} };
+				},
+			}) as never;
+
+		const { apiGet } = await import("../src/client.js");
+		await apiGet("compose.one", { composeId: "abc123", limit: 1 });
+
+		expect(urls[0]).toBe(
+			`/trpc/compose.one?input=${encodeURIComponent(
+				JSON.stringify({ json: { composeId: "abc123", limit: 1 } }),
+			)}`,
+		);
+	});
+
+	it("should omit the input query string when no params are passed", async () => {
+		process.env.DOKPLOY_URL = "https://test.dokploy.com";
+		process.env.DOKPLOY_API_KEY = "test-key-123";
+
+		const urls: string[] = [];
+		const axiosMock = await import("axios");
+		axiosMock.default.create = () =>
+			({
+				get: async (url: string) => {
+					urls.push(url);
+					return { data: {} };
+				},
+			}) as never;
+
+		const { apiGet } = await import("../src/client.js");
+		await apiGet("project.all");
+
+		expect(urls[0]).toBe("/trpc/project.all");
 	});
 });
 


### PR DESCRIPTION
Fixes #48

## What / Why

Previously, `apiGet()` serialized GET `input` query params as a bare JSON object:

```ts
`?input=${encodeURIComponent(JSON.stringify(params))}`
```

tRPC v11 servers (Dokploy server >= 0.30, `@trpc/server@11`) require the GET input query param to be wrapped in a `{ json: ... }` envelope. A bare object deserializes to `undefined`, causing every read-only command with query params (e.g., `application.search`, `compose one`, `project one`, `*.readLogs`) to fail with:

```text
Invalid input: expected object, received undefined (HTTP 400)
```

This PR updates `apiGet()` to send `{ json: params }` — the exact shape tRPC v11 requires. This envelope format is also fully backward compatible with older tRPC v10 servers, ensuring the CLI continues to work against all Dokploy server versions.

## Verification

- `dokploy application search --limit 1` against Dokploy server 0.30.2 (tRPC v11): 
  - Before: HTTP 400 
  - After: HTTP 200 with results
- `environment.search` with full query params: HTTP 200
- Added 2 unit tests asserting exact URL construction (with and without params).
- `vitest run`: 20/20 passed.

> **Note:** The alternative fix suggested in the issue (named query params via `{ params }`) was also tested against a tRPC v11 server, but it still returns HTTP 400. Only the `{ json: ... }` envelope works, and it maintains backward compatibility with tRPC v10.
