### PR TITLE
Fix parameterized GET requests and allowlist application mutation output

### DIFF
--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -70,6 +70,10 @@ interface CommandInfo {
 	method: "get" | "post";
 	description: string;
 	options: OptionInfo[];
+	outputProjection?: {
+		identifier?: "applicationId";
+		status: "created" | "deleted" | "moved" | "started" | "stopped";
+	};
 }
 
 interface OptionInfo {
@@ -138,6 +142,21 @@ function camelToKebab(s: string): string {
 	return s.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
 }
 
+function outputProjection(endpoint: string): CommandInfo["outputProjection"] {
+	switch (endpoint) {
+		case "application.create":
+			return { status: "created" };
+		case "application.delete":
+			return { identifier: "applicationId", status: "deleted" };
+		case "application.move":
+			return { identifier: "applicationId", status: "moved" };
+		case "application.start":
+			return { identifier: "applicationId", status: "started" };
+		case "application.stop":
+			return { identifier: "applicationId", status: "stopped" };
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Parse spec → CommandInfo[]
 // ---------------------------------------------------------------------------
@@ -165,6 +184,7 @@ function parseSpec(spec: OpenAPISpec): CommandInfo[] {
 				method: method as "get" | "post",
 				description: op.summary ?? op.description ?? `${group} ${action}`,
 				options,
+				outputProjection: outputProjection(endpoint),
 			});
 		}
 	}
@@ -208,6 +228,12 @@ function generateCommandCode(cmd: CommandInfo, groupVar: string): string {
 	const apiCall = cmd.method === "post"
 		? `await apiPost("${cmd.endpoint}", opts)`
 		: `await apiGet("${cmd.endpoint}", opts)`;
+	const projectionFields = cmd.outputProjection?.identifier
+		? `${cmd.outputProjection.identifier}: opts.${cmd.outputProjection.identifier}, `
+		: "";
+	const responseHandling = cmd.outputProjection
+		? `${apiCall};\n\t\t\tconst data = { ${projectionFields}status: "${cmd.outputProjection.status}" };`
+		: `const data = ${apiCall};`;
 
 	const escapedDesc = cmd.description.replace(/'/g, "\\'");
 
@@ -220,7 +246,7 @@ function generateCommandCode(cmd: CommandInfo, groupVar: string): string {
 		.action(async (opts: Record<string, any>) => {
 			const jsonOutput = opts.json; delete opts.json;
 ${coercions}
-			const data = ${apiCall};
+			${responseHandling}
 			if (jsonOutput) {
 				console.log(JSON.stringify(data, null, 2));
 			} else {

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -71,7 +71,10 @@ interface CommandInfo {
 	description: string;
 	options: OptionInfo[];
 	outputProjection?: {
-		identifier?: "applicationId";
+		identifier?: {
+			name: "applicationId";
+			source: "request" | "response";
+		};
 		status: "created" | "deleted" | "moved" | "started" | "stopped";
 	};
 }
@@ -145,15 +148,30 @@ function camelToKebab(s: string): string {
 function outputProjection(endpoint: string): CommandInfo["outputProjection"] {
 	switch (endpoint) {
 		case "application.create":
-			return { status: "created" };
+			return {
+				identifier: { name: "applicationId", source: "response" },
+				status: "created",
+			};
 		case "application.delete":
-			return { identifier: "applicationId", status: "deleted" };
+			return {
+				identifier: { name: "applicationId", source: "request" },
+				status: "deleted",
+			};
 		case "application.move":
-			return { identifier: "applicationId", status: "moved" };
+			return {
+				identifier: { name: "applicationId", source: "request" },
+				status: "moved",
+			};
 		case "application.start":
-			return { identifier: "applicationId", status: "started" };
+			return {
+				identifier: { name: "applicationId", source: "request" },
+				status: "started",
+			};
 		case "application.stop":
-			return { identifier: "applicationId", status: "stopped" };
+			return {
+				identifier: { name: "applicationId", source: "request" },
+				status: "stopped",
+			};
 	}
 }
 
@@ -228,11 +246,16 @@ function generateCommandCode(cmd: CommandInfo, groupVar: string): string {
 	const apiCall = cmd.method === "post"
 		? `await apiPost("${cmd.endpoint}", opts)`
 		: `await apiGet("${cmd.endpoint}", opts)`;
-	const projectionFields = cmd.outputProjection?.identifier
-		? `${cmd.outputProjection.identifier}: opts.${cmd.outputProjection.identifier}, `
+	const identifier = cmd.outputProjection?.identifier;
+	const responseVariable = identifier?.source === "response" ? "response" : "";
+	const projectionCall = responseVariable
+		? `const ${responseVariable} = ${apiCall};\n\t\t\tif (typeof ${responseVariable}?.${identifier.name} !== "string" || ${responseVariable}.${identifier.name}.length === 0) throw new Error("${cmd.endpoint} response missing ${identifier.name}");`
+		: `${apiCall};`;
+	const projectionFields = identifier
+		? `${identifier.name}: ${responseVariable || "opts"}.${identifier.name}, `
 		: "";
 	const responseHandling = cmd.outputProjection
-		? `${apiCall};\n\t\t\tconst data = { ${projectionFields}status: "${cmd.outputProjection.status}" };`
+		? `${projectionCall}\n\t\t\tconst data = { ${projectionFields}status: "${cmd.outputProjection.status}" };`
 		: `const data = ${apiCall};`;
 
 	const escapedDesc = cmd.description.replace(/'/g, "\\'");

--- a/src/client.ts
+++ b/src/client.ts
@@ -99,8 +99,7 @@ export async function apiGet(
 ) {
 	const client = createClient();
 	// The server runs tRPC with the SuperJSON transformer, so GET input must
-	// be sent in SuperJSON's serialized shape ({ json: ... }); a bare object
-	// deserializes to undefined and every parameterized query fails with 400.
+	// use its serialized { json: ... } envelope; a bare object gets a 400.
 	const query = params
 		? `?input=${encodeURIComponent(JSON.stringify({ json: params }))}`
 		: "";

--- a/src/client.ts
+++ b/src/client.ts
@@ -98,8 +98,11 @@ export async function apiGet(
 	params?: Record<string, unknown>,
 ) {
 	const client = createClient();
+	// The server runs tRPC with the SuperJSON transformer, so GET input must
+	// be sent in SuperJSON's serialized shape ({ json: ... }); a bare object
+	// deserializes to undefined and every parameterized query fails with 400.
 	const query = params
-		? `?input=${encodeURIComponent(JSON.stringify(params))}`
+		? `?input=${encodeURIComponent(JSON.stringify({ json: params }))}`
 		: "";
 	const response = await client.get(`/trpc/${endpoint}${query}`);
 	return response.data?.result?.data?.json ?? response.data;

--- a/src/client.ts
+++ b/src/client.ts
@@ -98,8 +98,7 @@ export async function apiGet(
 	params?: Record<string, unknown>,
 ) {
 	const client = createClient();
-	// The server runs tRPC with the SuperJSON transformer, so GET input must
-	// use its serialized { json: ... } envelope; a bare object gets a 400.
+	// tRPC SuperJSON input uses the { json: ... } envelope.
 	const query = params
 		? `?input=${encodeURIComponent(JSON.stringify({ json: params }))}`
 		: "";

--- a/src/generated/commands.ts
+++ b/src/generated/commands.ts
@@ -348,7 +348,8 @@ export function registerGeneratedCommands(program: Command) {
 		.action(async (opts: Record<string, any>) => {
 			const jsonOutput = opts.json; delete opts.json;
 
-			const data = await apiPost("application.create", opts);
+			await apiPost("application.create", opts);
+			const data = { status: "created" };
 			if (jsonOutput) {
 				console.log(JSON.stringify(data, null, 2));
 			} else {
@@ -364,7 +365,8 @@ export function registerGeneratedCommands(program: Command) {
 		.action(async (opts: Record<string, any>) => {
 			const jsonOutput = opts.json; delete opts.json;
 
-			const data = await apiPost("application.delete", opts);
+			await apiPost("application.delete", opts);
+			const data = { applicationId: opts.applicationId, status: "deleted" };
 			if (jsonOutput) {
 				console.log(JSON.stringify(data, null, 2));
 			} else {
@@ -463,7 +465,8 @@ export function registerGeneratedCommands(program: Command) {
 		.action(async (opts: Record<string, any>) => {
 			const jsonOutput = opts.json; delete opts.json;
 
-			const data = await apiPost("application.move", opts);
+			await apiPost("application.move", opts);
+			const data = { applicationId: opts.applicationId, status: "moved" };
 			if (jsonOutput) {
 				console.log(JSON.stringify(data, null, 2));
 			} else {
@@ -807,7 +810,8 @@ export function registerGeneratedCommands(program: Command) {
 		.action(async (opts: Record<string, any>) => {
 			const jsonOutput = opts.json; delete opts.json;
 
-			const data = await apiPost("application.start", opts);
+			await apiPost("application.start", opts);
+			const data = { applicationId: opts.applicationId, status: "started" };
 			if (jsonOutput) {
 				console.log(JSON.stringify(data, null, 2));
 			} else {
@@ -823,7 +827,8 @@ export function registerGeneratedCommands(program: Command) {
 		.action(async (opts: Record<string, any>) => {
 			const jsonOutput = opts.json; delete opts.json;
 
-			const data = await apiPost("application.stop", opts);
+			await apiPost("application.stop", opts);
+			const data = { applicationId: opts.applicationId, status: "stopped" };
 			if (jsonOutput) {
 				console.log(JSON.stringify(data, null, 2));
 			} else {

--- a/src/generated/commands.ts
+++ b/src/generated/commands.ts
@@ -348,8 +348,9 @@ export function registerGeneratedCommands(program: Command) {
 		.action(async (opts: Record<string, any>) => {
 			const jsonOutput = opts.json; delete opts.json;
 
-			await apiPost("application.create", opts);
-			const data = { status: "created" };
+			const response = await apiPost("application.create", opts);
+			if (typeof response?.applicationId !== "string" || response.applicationId.length === 0) throw new Error("application.create response missing applicationId");
+			const data = { applicationId: response.applicationId, status: "created" };
 			if (jsonOutput) {
 				console.log(JSON.stringify(data, null, 2));
 			} else {

--- a/tests/application-lifecycle-output.test.ts
+++ b/tests/application-lifecycle-output.test.ts
@@ -1,0 +1,142 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerGeneratedCommands } from "../src/generated/commands.js";
+
+const postSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/client.js", () => ({
+	apiGet: vi.fn(),
+	apiPost: postSpy,
+}));
+
+const cases = [
+	{
+		action: "create",
+		arguments: ["--name", "app", "--environmentId", "env-1"],
+		expectedInput: { environmentId: "env-1", name: "app" },
+		expectedOutput: { status: "created" },
+	},
+	{
+		action: "create",
+		arguments: ["--name", "app", "--environmentId", "env-1", "--json"],
+		expectedInput: { environmentId: "env-1", name: "app" },
+		expectedOutput: { status: "created" },
+	},
+	{
+		action: "move",
+		arguments: ["--applicationId", "app-1", "--targetEnvironmentId", "env-2"],
+		expectedInput: {
+			applicationId: "app-1",
+			targetEnvironmentId: "env-2",
+		},
+		expectedOutput: { applicationId: "app-1", status: "moved" },
+	},
+	{
+		action: "move",
+		arguments: [
+			"--applicationId",
+			"app-1",
+			"--targetEnvironmentId",
+			"env-2",
+			"--json",
+		],
+		expectedInput: {
+			applicationId: "app-1",
+			targetEnvironmentId: "env-2",
+		},
+		expectedOutput: { applicationId: "app-1", status: "moved" },
+	},
+	...(["delete", "start", "stop"] as const).flatMap((action) => {
+		const status = {
+			delete: "deleted",
+			start: "started",
+			stop: "stopped",
+		}[action];
+		return [
+			{
+				action,
+				arguments: ["--applicationId", "app-1"],
+				expectedInput: { applicationId: "app-1" },
+				expectedOutput: {
+					applicationId: "app-1",
+					status,
+				},
+			},
+			{
+				action,
+				arguments: ["--applicationId", "app-1", "--json"],
+				expectedInput: { applicationId: "app-1" },
+				expectedOutput: {
+					applicationId: "app-1",
+					status,
+				},
+			},
+		];
+	}),
+];
+
+describe("application lifecycle output", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		postSpy.mockReset();
+	});
+
+	it.each(cases)(
+		"should project a secret-free $expectedOutput.status result",
+		async ({
+			action,
+			arguments: commandArguments,
+			expectedInput,
+			expectedOutput,
+		}) => {
+			postSpy.mockResolvedValue({
+				applicationId: "app-1",
+				password: "must-not-appear",
+				refreshToken: "must-not-appear",
+			});
+			const output: string[] = [];
+			vi.spyOn(console, "log").mockImplementation((value) =>
+				output.push(String(value)),
+			);
+			const program = new Command();
+			registerGeneratedCommands(program);
+
+			await program.parseAsync([
+				"node",
+				"dokploy",
+				"application",
+				action,
+				...commandArguments,
+			]);
+
+			expect(postSpy).toHaveBeenCalledWith(
+				`application.${action}`,
+				expectedInput,
+			);
+			expect(JSON.parse(output.join("\n"))).toEqual(expectedOutput);
+			expect(output.join("\n")).not.toContain("must-not-appear");
+		},
+	);
+
+	it("should not print success when the mutation fails", async () => {
+		postSpy.mockRejectedValue(new Error("mutation failed"));
+		const output: string[] = [];
+		vi.spyOn(console, "log").mockImplementation((value) =>
+			output.push(String(value)),
+		);
+		const program = new Command();
+		registerGeneratedCommands(program);
+
+		await expect(
+			program.parseAsync([
+				"node",
+				"dokploy",
+				"application",
+				"stop",
+				"--applicationId",
+				"app-1",
+			]),
+		).rejects.toThrow("mutation failed");
+		expect(output).toEqual([]);
+	});
+});

--- a/tests/application-lifecycle-output.test.ts
+++ b/tests/application-lifecycle-output.test.ts
@@ -14,13 +14,13 @@ const cases = [
 		action: "create",
 		arguments: ["--name", "app", "--environmentId", "env-1"],
 		expectedInput: { environmentId: "env-1", name: "app" },
-		expectedOutput: { status: "created" },
+		expectedOutput: { applicationId: "app-1", status: "created" },
 	},
 	{
 		action: "create",
 		arguments: ["--name", "app", "--environmentId", "env-1", "--json"],
 		expectedInput: { environmentId: "env-1", name: "app" },
-		expectedOutput: { status: "created" },
+		expectedOutput: { applicationId: "app-1", status: "created" },
 	},
 	{
 		action: "move",
@@ -139,4 +139,42 @@ describe("application lifecycle output", () => {
 		).rejects.toThrow("mutation failed");
 		expect(output).toEqual([]);
 	});
+
+	it.each([
+		{
+			caseName: "missing",
+			response: { refreshToken: "must-not-appear" },
+		},
+		{
+			caseName: "not a string",
+			response: {
+				applicationId: { refreshToken: "must-not-appear" },
+			},
+		},
+	])(
+		"should fail closed when create identity is $caseName",
+		async ({ response }) => {
+			postSpy.mockResolvedValue(response);
+			const output: string[] = [];
+			vi.spyOn(console, "log").mockImplementation((value) =>
+				output.push(String(value)),
+			);
+			const program = new Command();
+			registerGeneratedCommands(program);
+
+			await expect(
+				program.parseAsync([
+					"node",
+					"dokploy",
+					"application",
+					"create",
+					"--name",
+					"app",
+					"--environmentId",
+					"env-1",
+				]),
+			).rejects.toThrow("application.create response missing applicationId");
+			expect(output).toEqual([]);
+		},
+	);
 });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const getSpy = vi.hoisted(() => vi.fn());
+
 vi.mock("axios", () => {
 	return {
 		default: {
 			create: () => ({
-				get: () => Promise.resolve({ data: {} }),
+				get: getSpy,
 				post: () => Promise.resolve({ data: {} }),
 			}),
 		},
@@ -60,40 +62,35 @@ describe("readAuthConfig", () => {
 });
 
 describe("apiGet", () => {
-	const urls: string[] = [];
-
-	beforeEach(async () => {
+	beforeEach(() => {
 		process.env.DOKPLOY_URL = "https://test.dokploy.com";
 		process.env.DOKPLOY_API_KEY = "test-key-123";
-		urls.length = 0;
-		const axiosMock = await import("axios");
-		axiosMock.default.create = () =>
-			({
-				get: async (url: string) => {
-					urls.push(url);
-					return { data: {} };
-				},
-			}) as never;
+		getSpy.mockReset().mockResolvedValue({ data: {} });
 	});
 
 	it("should wrap GET params in the SuperJSON { json: ... } input envelope", async () => {
 		const { apiGet } = await import("../src/client.js");
 		await apiGet("compose.one", { composeId: "abc123", limit: 1 });
 
-		expect(urls[0]).toBe(
+		expect(getSpy).toHaveBeenCalledWith(
 			`/trpc/compose.one?input=${encodeURIComponent(
 				JSON.stringify({ json: { composeId: "abc123", limit: 1 } }),
 			)}`,
 		);
 	});
 
-	it("should encode the empty opts object generated parameterless commands pass", async () => {
+	it("should omit the input query string when params are undefined", async () => {
 		const { apiGet } = await import("../src/client.js");
-		// Generated commands always pass Commander's opts, which is {} for
-		// parameterless commands once --json is stripped.
+		await apiGet("project.all");
+
+		expect(getSpy).toHaveBeenCalledWith("/trpc/project.all");
+	});
+
+	it("should send an empty { json: {} } envelope when params are an empty object", async () => {
+		const { apiGet } = await import("../src/client.js");
 		await apiGet("project.all", {});
 
-		expect(urls[0]).toBe(
+		expect(getSpy).toHaveBeenCalledWith(
 			`/trpc/project.all?input=${encodeURIComponent(JSON.stringify({ json: {} }))}`,
 		);
 	});

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -103,6 +103,30 @@ describe("apiGet", () => {
 
 		expect(urls[0]).toBe("/trpc/project.all");
 	});
+
+	it("should encode the empty opts object generated parameterless commands pass", async () => {
+		process.env.DOKPLOY_URL = "https://test.dokploy.com";
+		process.env.DOKPLOY_API_KEY = "test-key-123";
+
+		const urls: string[] = [];
+		const axiosMock = await import("axios");
+		axiosMock.default.create = () =>
+			({
+				get: async (url: string) => {
+					urls.push(url);
+					return { data: {} };
+				},
+			}) as never;
+
+		const { apiGet } = await import("../src/client.js");
+		// Generated commands always pass Commander's opts object, which is {}
+		// for parameterless commands once --json is stripped.
+		await apiGet("project.all", {});
+
+		expect(urls[0]).toBe(
+			`/trpc/project.all?input=${encodeURIComponent(JSON.stringify({ json: {} }))}`,
+		);
+	});
 });
 
 describe("saveAuthConfig", () => {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -60,11 +60,12 @@ describe("readAuthConfig", () => {
 });
 
 describe("apiGet", () => {
-	it("should wrap GET params in the SuperJSON { json: ... } input envelope", async () => {
+	const urls: string[] = [];
+
+	beforeEach(async () => {
 		process.env.DOKPLOY_URL = "https://test.dokploy.com";
 		process.env.DOKPLOY_API_KEY = "test-key-123";
-
-		const urls: string[] = [];
+		urls.length = 0;
 		const axiosMock = await import("axios");
 		axiosMock.default.create = () =>
 			({
@@ -73,7 +74,9 @@ describe("apiGet", () => {
 					return { data: {} };
 				},
 			}) as never;
+	});
 
+	it("should wrap GET params in the SuperJSON { json: ... } input envelope", async () => {
 		const { apiGet } = await import("../src/client.js");
 		await apiGet("compose.one", { composeId: "abc123", limit: 1 });
 
@@ -84,43 +87,10 @@ describe("apiGet", () => {
 		);
 	});
 
-	it("should omit the input query string when no params are passed", async () => {
-		process.env.DOKPLOY_URL = "https://test.dokploy.com";
-		process.env.DOKPLOY_API_KEY = "test-key-123";
-
-		const urls: string[] = [];
-		const axiosMock = await import("axios");
-		axiosMock.default.create = () =>
-			({
-				get: async (url: string) => {
-					urls.push(url);
-					return { data: {} };
-				},
-			}) as never;
-
-		const { apiGet } = await import("../src/client.js");
-		await apiGet("project.all");
-
-		expect(urls[0]).toBe("/trpc/project.all");
-	});
-
 	it("should encode the empty opts object generated parameterless commands pass", async () => {
-		process.env.DOKPLOY_URL = "https://test.dokploy.com";
-		process.env.DOKPLOY_API_KEY = "test-key-123";
-
-		const urls: string[] = [];
-		const axiosMock = await import("axios");
-		axiosMock.default.create = () =>
-			({
-				get: async (url: string) => {
-					urls.push(url);
-					return { data: {} };
-				},
-			}) as never;
-
 		const { apiGet } = await import("../src/client.js");
-		// Generated commands always pass Commander's opts object, which is {}
-		// for parameterless commands once --json is stripped.
+		// Generated commands always pass Commander's opts, which is {} for
+		// parameterless commands once --json is stripped.
 		await apiGet("project.all", {});
 
 		expect(urls[0]).toBe(

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,5 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("axios", () => {
+	return {
+		default: {
+			create: () => ({
+				get: () => Promise.resolve({ data: {} }),
+				post: () => Promise.resolve({ data: {} }),
+			}),
+		},
+	};
+});
+
 describe("readAuthConfig", () => {
 	const originalEnv = { ...process.env };
 
@@ -45,6 +56,52 @@ describe("readAuthConfig", () => {
 		const config = readAuthConfig();
 
 		expect(config.token).toBe("api-key");
+	});
+});
+
+describe("apiGet", () => {
+	it("should wrap GET params in the SuperJSON { json: ... } input envelope", async () => {
+		process.env.DOKPLOY_URL = "https://test.dokploy.com";
+		process.env.DOKPLOY_API_KEY = "test-key-123";
+
+		const urls: string[] = [];
+		const axiosMock = await import("axios");
+		axiosMock.default.create = () =>
+			({
+				get: async (url: string) => {
+					urls.push(url);
+					return { data: {} };
+				},
+			}) as never;
+
+		const { apiGet } = await import("../src/client.js");
+		await apiGet("compose.one", { composeId: "abc123", limit: 1 });
+
+		expect(urls[0]).toBe(
+			`/trpc/compose.one?input=${encodeURIComponent(
+				JSON.stringify({ json: { composeId: "abc123", limit: 1 } }),
+			)}`,
+		);
+	});
+
+	it("should omit the input query string when no params are passed", async () => {
+		process.env.DOKPLOY_URL = "https://test.dokploy.com";
+		process.env.DOKPLOY_API_KEY = "test-key-123";
+
+		const urls: string[] = [];
+		const axiosMock = await import("axios");
+		axiosMock.default.create = () =>
+			({
+				get: async (url: string) => {
+					urls.push(url);
+					return { data: {} };
+				},
+			}) as never;
+
+		const { apiGet } = await import("../src/client.js");
+		await apiGet("project.all");
+
+		expect(urls[0]).toBe("/trpc/project.all");
 	});
 });
 

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { apiGet } from "../src/client.js";
 
 const getSpy = vi.hoisted(() => vi.fn());
 
@@ -7,7 +8,6 @@ vi.mock("axios", () => {
 		default: {
 			create: () => ({
 				get: getSpy,
-				post: () => Promise.resolve({ data: {} }),
 			}),
 		},
 	};
@@ -69,7 +69,6 @@ describe("apiGet", () => {
 	});
 
 	it("should wrap GET params in the SuperJSON { json: ... } input envelope", async () => {
-		const { apiGet } = await import("../src/client.js");
 		await apiGet("compose.one", { composeId: "abc123", limit: 1 });
 
 		expect(getSpy).toHaveBeenCalledWith(
@@ -80,14 +79,12 @@ describe("apiGet", () => {
 	});
 
 	it("should omit the input query string when params are undefined", async () => {
-		const { apiGet } = await import("../src/client.js");
 		await apiGet("project.all");
 
 		expect(getSpy).toHaveBeenCalledWith("/trpc/project.all");
 	});
 
 	it("should send an empty { json: {} } envelope when params are an empty object", async () => {
-		const { apiGet } = await import("../src/client.js");
 		await apiGet("project.all", {});
 
 		expect(getSpy).toHaveBeenCalledWith(

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -62,10 +62,16 @@ describe("readAuthConfig", () => {
 });
 
 describe("apiGet", () => {
+	const originalEnv = { ...process.env };
+
 	beforeEach(() => {
 		process.env.DOKPLOY_URL = "https://test.dokploy.com";
 		process.env.DOKPLOY_API_KEY = "test-key-123";
 		getSpy.mockReset().mockResolvedValue({ data: {} });
+	});
+
+	afterEach(() => {
+		process.env = { ...originalEnv };
 	});
 
 	it("should wrap GET params in the SuperJSON { json: ... } input envelope", async () => {


### PR DESCRIPTION
## Summary

- wrap parameterized tRPC GET input in the required SuperJSON JSON envelope
- prevent application create, delete, move, start, and stop commands from printing full application resources
- emit minimal local success projections only after the mutation succeeds
- cover request shapes, plain and JSON output, response-secret exclusion, and failed mutations

## Verification

- TypeScript build passes
- Vitest: 4 files, 32 tests passed
- generated commands refreshed from the canonical generator
- git diff check passes